### PR TITLE
Fixed Java-like constructor in PHP's "Replace Method with Method Object"

### DIFF
--- a/interactive/php/replace-method-with-method-object.md
+++ b/interactive/php/replace-method-with-method-object.md
@@ -79,7 +79,7 @@ class Gamma {
   private $quantity;
   private $yearToDate;
 
-  public Gamma(Account $source, $inputValArg, $quantityArg, $yearToDateArg) {
+  public function __construct(Account $source, $inputValArg, $quantityArg, $yearToDateArg) {
     $this->account = $source;
     $this->inputVal = $inputValArg;
     $this->quantity = $quantityArg;


### PR DESCRIPTION
```
<br />
<b>Parse error</b>:  syntax error, unexpected 'Gamma' (T_STRING), expecting function (T_FUNCTION) or const (T_CONST) in <b>[...][...]</b> on line <b>19</b><br />
```

http://sandbox.onlinephpfunctions.com/code/02ba9c497766d6529f02f5f3ec044f86bbd5304f